### PR TITLE
Bugfix: Solucionar error al inicio del servidor de test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p ./tsconfig.json",
     "start:dev": "cross-env NODE_ENV=development tsc-watch --noClear -p ./tsconfig.json --onSuccess \"node ./dist/app.js\"",
     "start": "tsc-watch --noClear -p ./tsconfig.json --onSuccess \"node ./dist/app.js\"",
-    "start:test": "cross-env NODE_ENV=test tsc-watch --noClear -p ./tsconfig.json --onSuccess \"node ./dist/shared/db/seeder.js && node ./dist/app.js\"",
+    "start:test": "cross-env NODE_ENV=test pnpm run seed:test && cross-env NODE_ENV=test tsc-watch --noClear -p ./tsconfig.json --onSuccess \"node ./dist/app.js\"",
     "seed": "pnpm run build && node ./dist/shared/db/seeder.js",
     "seed:test": "cross-env NODE_ENV=test pnpm run build && node ./dist/shared/db/seeder.js"
   },


### PR DESCRIPTION
**Problema**: El script `start:test` ejecutaba el seeder pero no iniciaba el servidor después, debido a que el seeder cerraba la conexión ORM y terminaba el proceso.

**Solución**: Se separó la ejecución del seeder del inicio del servidor:
- Primero ejecuta `seed:test` para poblar la base de datos
- Luego inicia el servidor de desarrollo con `tsc-watch`

**Cambios**:
- Modificado el script `start:test` en `package.json` para ejecutar el seeder y servidor de forma secuencial en lugar de concurrente

**Pruebas**: Ejecutar `pnpm run start:test` para verificar que tanto el seeding de la base de datos como el inicio del servidor funcionen correctamente.